### PR TITLE
Update links to Shortbread Tiles schema

### DIFF
--- a/docs/pages/overview.html
+++ b/docs/pages/overview.html
@@ -37,7 +37,7 @@
 		</tr>
 		<tr>
 			<th>{{{chart_flow 1}}}</th>
-			<td><em>Generator produces vector tiles.</em><br> We are using <a href="https://tilemaker.org/" rel="follow">tilemaker</a> to generate vector tiles in <a href="https://shortbread.geofabrik.de/schema/" rel="follow">shortbread scheme</a>.</td>
+			<td><em>Generator produces vector tiles.</em><br> We are using <a href="https://tilemaker.org/" rel="follow">tilemaker</a> to generate vector tiles in <a href="https://shortbread-tiles.org/schema/" rel="follow">shortbread schema</a>.</td>
 		</tr>
 		<tr>
 			<th>{{{chart_flow 2}}}</th>
@@ -76,7 +76,7 @@
 			<td>Enjoy.</td>
 		</tr>
 	</table>
-	<p>We combined permissively licensed open source software, data, schemes and styles, such as <a href="https://tilemaker.org/" rel="follow">tilemaker</a>, <a href="https://shortbread.geofabrik.de/schema/" rel="follow">Geofabrik Shortbread</a> and <a href="https://maplibre.org/" rel="follow">MapLibre</a>.</p>
+	<p>We combined permissively licensed open source software, data, schema and styles, such as <a href="https://tilemaker.org/" rel="follow">tilemaker</a>, <a href="https://shortbread-tiles.org/schema/" rel="follow">Shortbread Tiles Schema</a> and <a href="https://maplibre.org/" rel="follow">MapLibre</a>.</p>
 	<p>VersaTiles lets you use OpenStreetMap based vector tiles, without any restrictions, locked-in paid services or attribution requirements beyond OpenStreetMap. You can use the <a href="https://download.versatiles.org">freely downloadable tilesets from VersaTiles</a> on your own infrastructure, in any way you like. Our open spec, royalty free and permissively licensed <a href="">container format</a> works with virtually any webserver or <abbr title="Content Delivery Network">CDN</abbr> — with no requirement to pay unreasonable prices for "Tiles-as-a-Service".</p>
 </section>
 <section>


### PR DESCRIPTION
Shortbread started out as a Geofabrik project, but is being migrated to the wider Shortbread/OpenStreetMap community. This patch updates the URLs to use the current shortbread-tiles.org website.

It also corrects the term from “scheme” to “schema”.